### PR TITLE
Clamp lessons remaining to zero

### DIFF
--- a/backend/src/lessons/lessons.controller.spec.ts
+++ b/backend/src/lessons/lessons.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LessonsController } from './lessons.controller';
+import { LessonsService } from './lessons.service';
 
 describe('LessonsController', () => {
   let controller: LessonsController;
@@ -7,6 +8,7 @@ describe('LessonsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LessonsController],
+      providers: [{ provide: LessonsService, useValue: {} }],
     }).compile();
 
     controller = module.get<LessonsController>(LessonsController);

--- a/backend/src/lessons/lessons.service.spec.ts
+++ b/backend/src/lessons/lessons.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LessonsService } from './lessons.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Lesson } from '../entities/lesson.entity';
+import { Student } from '../entities/student.entity';
 
 describe('LessonsService', () => {
   let service: LessonsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LessonsService],
+      providers: [
+        LessonsService,
+        { provide: getRepositoryToken(Lesson), useValue: {} },
+        { provide: getRepositoryToken(Student), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<LessonsService>(LessonsService);

--- a/backend/src/payments/payments.controller.spec.ts
+++ b/backend/src/payments/payments.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PaymentsController } from './payments.controller';
+import { PaymentsService } from './payments.service';
 
 describe('PaymentsController', () => {
   let controller: PaymentsController;
@@ -7,6 +8,7 @@ describe('PaymentsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PaymentsController],
+      providers: [{ provide: PaymentsService, useValue: {} }],
     }).compile();
 
     controller = module.get<PaymentsController>(PaymentsController);

--- a/backend/src/payments/payments.service.spec.ts
+++ b/backend/src/payments/payments.service.spec.ts
@@ -1,12 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PaymentsService } from './payments.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Payment } from '../entities/payment.entity';
+import { Student } from '../entities/student.entity';
 
 describe('PaymentsService', () => {
   let service: PaymentsService;
 
+  const paymentRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+  const studentRepo = {
+    findOne: jest.fn(),
+  };
+
   beforeEach(async () => {
+    paymentRepo.createQueryBuilder.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn().mockResolvedValue({ lessonsCount: '3', amount: '30' }),
+    });
+    studentRepo.findOne.mockResolvedValue({
+      id: 1,
+      firstName: 'Test',
+      lastName: 'User',
+      totalLessonsCompleted: 5,
+      pricePerHour: 10,
+    });
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PaymentsService],
+      providers: [
+        PaymentsService,
+        { provide: getRepositoryToken(Payment), useValue: paymentRepo },
+        { provide: getRepositoryToken(Student), useValue: studentRepo },
+      ],
     }).compile();
 
     service = module.get<PaymentsService>(PaymentsService);
@@ -14,5 +43,12 @@ describe('PaymentsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('calculateStudentBalance', () => {
+    it('should not return negative lessonsRemaining', async () => {
+      const result = await service.calculateStudentBalance(1);
+      expect(result.lessonsRemaining).toBe(0);
+    });
   });
 });

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -190,7 +190,7 @@ export class PaymentsService {
     const lessonsPaid = parseInt(totalPaidResult.lessonsCount) || 0;
     const amountPaid = parseFloat(totalPaidResult.amount) || 0;
     const lessonsCompleted = student.totalLessonsCompleted;
-    const lessonsRemaining = lessonsPaid - lessonsCompleted;
+    const lessonsRemaining = Math.max(0, lessonsPaid - lessonsCompleted);
     const amountDue = Math.max(0, lessonsCompleted - lessonsPaid) * student.pricePerHour;
 
     return {

--- a/backend/src/students/students.controller.spec.ts
+++ b/backend/src/students/students.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { StudentsController } from './students.controller';
+import { StudentsService } from './students.service';
 
 describe('StudentsController', () => {
   let controller: StudentsController;
@@ -7,6 +8,7 @@ describe('StudentsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [StudentsController],
+      providers: [{ provide: StudentsService, useValue: {} }],
     }).compile();
 
     controller = module.get<StudentsController>(StudentsController);

--- a/backend/src/students/students.service.spec.ts
+++ b/backend/src/students/students.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { StudentsService } from './students.service';
+import { LessonsService } from '../lessons/lessons.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Student } from '../entities/student.entity';
 
 describe('StudentsService', () => {
   let service: StudentsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StudentsService],
+      providers: [
+        StudentsService,
+        { provide: LessonsService, useValue: { autoCompleteLessons: jest.fn() } },
+        { provide: getRepositoryToken(Student), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<StudentsService>(StudentsService);
@@ -14,5 +21,20 @@ describe('StudentsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getStudentStats', () => {
+    it('should not return negative lessonsRemaining', async () => {
+      const mockStudent = {
+        totalLessonsCompleted: 5,
+        totalAmountPaid: 0,
+        totalAmountDue: 0,
+        totalLessonsPaid: 3,
+        status: 'active',
+      } as any;
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockStudent);
+      const stats = await service.getStudentStats(1);
+      expect(stats.lessonsRemaining).toBe(0);
+    });
   });
 });

--- a/backend/src/students/students.service.ts
+++ b/backend/src/students/students.service.ts
@@ -101,7 +101,7 @@ export class StudentsService {
       totalLessons: student.totalLessonsCompleted,
       totalPaid: student.totalAmountPaid,
       totalDue: student.totalAmountDue,
-      lessonsRemaining: student.totalLessonsPaid - student.totalLessonsCompleted,
+      lessonsRemaining: Math.max(0, student.totalLessonsPaid - student.totalLessonsCompleted),
       status: student.status
     };
   }


### PR DESCRIPTION
## Summary
- Prevent negative `lessonsRemaining` values in student stats and payment balance calculations
- Add unit tests ensuring `lessonsRemaining` is always non-negative and mock dependencies for controllers/services

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689366c42e2c8328af5f4b3873bfe10a