### PR TITLE
feat(frontend): add reusable loading and theme

### DIFF
--- a/frontend/src/components/common/Loading.tsx
+++ b/frontend/src/components/common/Loading.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Typography, Grid, Card } from '@mui/material';
+
+interface LoadingProps {
+  title?: string;
+  cards?: number;
+}
+
+const Loading: React.FC<LoadingProps> = ({ title = 'جاري التحميل...', cards = 4 }) => {
+  return (
+    <Box sx={{ p: 3 }} className="fade-in">
+      <Typography variant="h4" sx={{ mb: 3, fontFamily: '"Amiri", serif', color: '#1F2937' }}>
+        {title}
+      </Typography>
+      <Grid container spacing={3}>
+        {Array.from({ length: cards }).map((_, idx) => (
+          // FIXED: Using the 'size' prop as required by MUI v5 Grid
+          <Grid key={idx} size={{ xs: 12, sm: 6, md: 3 }}>
+            <Card
+              sx={{
+                height: 160,
+                background: 'linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)',
+                backgroundSize: '1000px 100%',
+                animation: 'shimmer 2s infinite'
+              }}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default Loading;

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -26,6 +26,7 @@ import { getLessons } from '../../services/lessonService';
 import { getPayments } from '../../services/paymentService';
 import { Student, Lesson, Payment } from '../../types';
 import { formatCurrency } from '../../utils/currency';
+import Loading from '../common/Loading';
 
 interface DashboardStats {
   totalStudents: number;
@@ -281,28 +282,14 @@ const Dashboard: React.FC = () => {
   }, []);
 
   if (loading) {
-    return (
-      <Box sx={{ p: 3 }}>
-        <Typography variant="h4" sx={{ mb: 3, fontFamily: '"Amiri", serif', color: '#1F2937' }}>
-          جاري التحميل...
-        </Typography>
-        <Grid container spacing={3}>
-          {/* FIXED: Using the 'size' prop as required by your project's MUI version */}
-          {[1, 2, 3, 4].map((item) => (
-            <Grid size={{ xs: 12, sm: 6, md: 3 }} key={item}>
-              <Card sx={{ height: 160, background: 'linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)', backgroundSize: '1000px 100%', animation: 'shimmer 2s infinite' }} />
-            </Grid>
-          ))}
-        </Grid>
-      </Box>
-    );
+    return <Loading />;
   }
 
   const completionRate = stats.totalLessons > 0 ? (stats.completedLessons / stats.totalLessons) * 100 : 0;
   const activeRate = stats.totalStudents > 0 ? (stats.activeStudents / stats.totalStudents) * 100 : 0;
 
   return (
-    <Box sx={{ p: isMobile ? 2 : 3 }}>
+    <Box sx={{ p: isMobile ? 2 : 3 }} className="fade-in">
       {/* Header */}
       <Box sx={{ mb: 4 }}>
         <Typography

--- a/frontend/src/components/lessons/LessonCalendar.tsx
+++ b/frontend/src/components/lessons/LessonCalendar.tsx
@@ -3,6 +3,7 @@ import { Lesson, Student } from '../../types';
 import { getLessons, createLesson, updateLesson, deleteLesson } from '../../services/lessonService';
 import { getStudents } from '../../services/studentService';
 import LessonForm from './LessonForm';
+import Loading from '../common/Loading';
 import {
   Box,
   Typography,
@@ -28,12 +29,17 @@ const LessonCalendar: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
   const [dialogTitle, setDialogTitle] = useState('إضافة درس جديد');
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     (async () => {
-      const [lessonData, studentData] = await Promise.all([getLessons(), getStudents()]);
-      setLessons(lessonData);
-      setStudents(studentData);
+      try {
+        const [lessonData, studentData] = await Promise.all([getLessons(), getStudents()]);
+        setLessons(lessonData);
+        setStudents(studentData);
+      } finally {
+        setLoading(false);
+      }
     })();
   }, []);
 
@@ -75,6 +81,10 @@ const LessonCalendar: React.FC = () => {
     setLessons(prev => prev.filter(l => l.id !== id));
   };
 
+  if (loading) {
+    return <Loading />;
+  }
+
   return (
     <Box
       sx={{
@@ -83,6 +93,7 @@ const LessonCalendar: React.FC = () => {
         minHeight: '100vh',
         position: 'relative',
       }}
+      className="fade-in"
     >
       <Typography
         variant={isMobile ? 'h5' : 'h4'}

--- a/frontend/src/components/payements/PaymentTracker.tsx
+++ b/frontend/src/components/payements/PaymentTracker.tsx
@@ -36,6 +36,7 @@ import {
   ConfirmationNumber,
 } from '@mui/icons-material';
 import { Payment, Student } from '../../types';
+import Loading from '../common/Loading';
 import { getPayments, createPayment, updatePayment, deletePayment } from '../../services/paymentService';
 import { getStudents } from '../../services/studentService';
 import { formatCurrency } from '../../utils/currency';
@@ -127,6 +128,7 @@ const PaymentTracker: React.FC = () => {
   });
   const [dialogTitle, setDialogTitle] = useState('إضافة دفعة جديدة');
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -137,6 +139,8 @@ const PaymentTracker: React.FC = () => {
       } catch (error) {
         console.error("Failed to fetch data:", error);
         setAlert({ type: 'error', message: 'فشل تحميل البيانات' });
+      } finally {
+        setLoading(false);
       }
     };
     fetchData();
@@ -211,8 +215,12 @@ const PaymentTracker: React.FC = () => {
     }
   };
 
+  if (loading) {
+    return <Loading />;
+  }
+
   return (
-    <Box sx={{ p: isMobile ? 2 : 3, pb: 10 }}>
+    <Box sx={{ p: isMobile ? 2 : 3, pb: 10 }} className="fade-in">
       <Typography variant={isMobile ? 'h5' : 'h4'} sx={{ mb: 3, fontWeight: 700 }}>
         إدارة الدفعات
       </Typography>

--- a/frontend/src/components/students/StudentList.tsx
+++ b/frontend/src/components/students/StudentList.tsx
@@ -37,6 +37,7 @@ import { Student } from '../../types';
 import { getStudents, createStudent, deleteStudent, updateStudent } from '../../services/studentService';
 import { formatCurrency } from '../../utils/currency';
 import StudentCard from './StudentCard';
+import Loading from '../common/Loading';
 
 const StudentList: React.FC = () => {
   const theme = useTheme();
@@ -57,6 +58,7 @@ const StudentList: React.FC = () => {
   });
 
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     (async () => {
@@ -66,6 +68,8 @@ const StudentList: React.FC = () => {
         setFiltered(list);
       } catch (err) {
         console.error(err);
+      } finally {
+        setLoading(false);
       }
     })();
   }, []);
@@ -145,8 +149,12 @@ const StudentList: React.FC = () => {
     }
   };
 
+  if (loading) {
+    return <Loading />;
+  }
+
   return (
-    <Box sx={{ p: isMobile ? 2 : 3, pb: 10 /* Add padding to bottom to avoid overlap with FAB */ }}>
+    <Box sx={{ p: isMobile ? 2 : 3, pb: 10 /* Add padding to bottom to avoid overlap with FAB */ }} className="fade-in">
       {/* Header & Search */}
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 3, gap: 2 }}>
         <Typography variant={isMobile ? 'h5' : 'h4'} sx={{ flexGrow: 1 }}>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,13 +3,18 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import theme from './theme';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,22 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#4A90E2' },
+    secondary: { main: '#16A34A' },
+    background: {
+      default: '#F8FAFC',
+      paper: 'rgba(255,255,255,0.7)',
+    },
+  },
+  typography: {
+    fontFamily: '"Cairo", sans-serif',
+    h1: { fontFamily: '"Amiri", serif' },
+    h2: { fontFamily: '"Amiri", serif' },
+    h3: { fontFamily: '"Amiri", serif' },
+    h4: { fontFamily: '"Amiri", serif' },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- add shared Loading component with shimmering cards and fade-in animation
- use Loading across dashboard, student, lesson, and payment modules
- apply global light theme via MUI ThemeProvider for cohesive look

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894856153848328a35a67d64d102bef