### PR TITLE
feat: improve lesson list layout

### DIFF
--- a/frontend/src/components/lessons/LessonCalendar.tsx
+++ b/frontend/src/components/lessons/LessonCalendar.tsx
@@ -4,16 +4,14 @@ import { getLessons, createLesson, updateLesson, deleteLesson } from '../../serv
 import { getStudents } from '../../services/studentService';
 import LessonForm from './LessonForm';
 import Loading from '../common/Loading';
+import LessonCard from './LessonCard';
 import {
   Box,
   Typography,
   Grid,
-  Card,
-  CardContent,
   Dialog,
   DialogTitle,
   DialogContent,
-  Button,
   useTheme,
   useMediaQuery,
   Fab,
@@ -85,10 +83,17 @@ const LessonCalendar: React.FC = () => {
     return <Loading />;
   }
 
+  const todayLessons = lessons.filter(l => {
+    const d = new Date(l.scheduledDateTime);
+    const now = new Date();
+    return d.toDateString() === now.toDateString() && l.status !== 'completed';
+  });
+
   return (
     <Box
       sx={{
         p: isMobile ? 2 : 3,
+        pb: 10,
         bgcolor: 'background.default',
         minHeight: '100vh',
         position: 'relative',
@@ -102,29 +107,24 @@ const LessonCalendar: React.FC = () => {
         الجدول الزمني للدروس
       </Typography>
 
-      <Grid container spacing={2}>
+      {todayLessons.length > 0 && (
+        <Typography
+          variant="subtitle1"
+          sx={{ mb: 2, fontWeight: 600, color: 'warning.main', textAlign: 'center' }}
+        >
+          لديك {todayLessons.length} دروس اليوم
+        </Typography>
+      )}
+
+      <Grid container spacing={3}>
         {lessons.map(lesson => (
-          // FIXED: Changed 'item' and 'xs' props to the 'size' prop.
-          <Grid size={{ xs: 12 }} key={lesson.id}>
-            <Card sx={{ backdropFilter: 'blur(16px)', background: 'rgba(55, 57, 55, 1)', borderRadius: 2 }}>
-              <CardContent>
-                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                  الطالب: {students.find(s => s.id === lesson.studentId)?.firstName} {' '}
-                  {students.find(s => s.id === lesson.studentId)?.lastName}
-                </Typography>
-                <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
-                  {new Date(lesson.scheduledDateTime).toLocaleDateString('ar-TN')} {' '}
-                  {new Date(lesson.scheduledDateTime).toLocaleTimeString('ar-TN', { hour: '2-digit', minute: '2-digit' })}
-                </Typography>
-                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                  المدة: {lesson.durationMinutes} دقيقة
-                </Typography>
-                <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
-                  <Button size="small" onClick={() => handleOpen(lesson)}>تعديل</Button>
-                  <Button size="small" color="error" onClick={() => handleDeleteLesson(lesson.id)}>حذف</Button>
-                </Box>
-              </CardContent>
-            </Card>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={lesson.id}>
+            <LessonCard
+              lesson={lesson}
+              student={students.find(s => s.id === lesson.studentId)}
+              onEdit={() => handleOpen(lesson)}
+              onDelete={handleDeleteLesson}
+            />
           </Grid>
         ))}
       </Grid>

--- a/frontend/src/components/lessons/LessonCard.tsx
+++ b/frontend/src/components/lessons/LessonCard.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { Lesson, Student } from '../../types';
+import {
+  Card,
+  CardContent,
+  Box,
+  Typography,
+  IconButton,
+  Collapse,
+  Chip,
+  Button,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import {
+  ExpandMore,
+  ExpandLess,
+  Edit,
+  Delete as DeleteIcon,
+} from '@mui/icons-material';
+
+interface LessonCardProps {
+  lesson: Lesson;
+  student?: Student;
+  onEdit: (lesson: Lesson) => void;
+  onDelete: (id: number) => void;
+}
+
+const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDelete }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [expanded, setExpanded] = useState(false);
+
+  const scheduledDate = new Date(lesson.scheduledDateTime);
+  const isSameDay = (d1: Date, d2: Date) => d1.toDateString() === d2.toDateString();
+  const isToday = isSameDay(scheduledDate, new Date()) && lesson.status !== 'completed';
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return '#16A34A';
+      case 'scheduled':
+        return '#2563EB';
+      case 'cancelled':
+        return '#DC2626';
+      default:
+        return '#6B7280';
+    }
+  };
+
+  return (
+    <Card
+      sx={{
+        background: 'rgba(255,255,255,0.9)',
+        backdropFilter: 'blur(20px)',
+        borderRadius: 2,
+        border: '1px solid rgba(255,255,255,0.2)',
+        overflow: 'hidden',
+        position: 'relative',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '4px',
+          background: isToday
+            ? `linear-gradient(90deg, #F59E0B, #F59E0BCC)`
+            : `linear-gradient(90deg, ${getStatusColor(lesson.status)}, ${getStatusColor(lesson.status)}CC)`,
+        },
+      }}
+    >
+      <CardContent sx={{ p: isMobile ? 2 : 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant={isMobile ? 'subtitle1' : 'h6'}
+              sx={{ fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+            >
+              {student?.firstName} {student?.lastName}
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              {scheduledDate.toLocaleDateString('ar-TN')} {' '}
+              {scheduledDate.toLocaleTimeString('ar-TN', { hour: '2-digit', minute: '2-digit' })}
+            </Typography>
+          </Box>
+          {isToday && (
+            <Chip label="درس اليوم" color="warning" size="small" sx={{ fontWeight: 600, mr: 1 }} />
+          )}
+          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#2563EB' }}>
+            {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+          </IconButton>
+        </Box>
+
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 0.5 }}>
+            المدة: {lesson.durationMinutes} دقيقة
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 0.5 }}>
+            النوع: {lesson.lessonType}
+          </Typography>
+          {lesson.notes && (
+            <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
+              ملاحظات: {lesson.notes}
+            </Typography>
+          )}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <Button size="small" onClick={() => onEdit(lesson)} startIcon={<Edit fontSize="small" />}>
+              تعديل
+            </Button>
+            <Button
+              size="small"
+              color="error"
+              onClick={() => onDelete(lesson.id)}
+              startIcon={<DeleteIcon fontSize="small" />}
+            >
+              حذف
+            </Button>
+          </Box>
+        </Collapse>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LessonCard;


### PR DESCRIPTION
## Summary
- replace bulky lesson list with compact LessonCard component and expandable details
- highlight today's scheduled lessons and ensure add button stays visible

## Testing
- `npm test --silent -- --watchAll=false` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68960d92e13c8328b131c4dd554e4dde