### PR TITLE
feat: add notifications for lesson reminders

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,8 @@ import { Student } from './entities/student.entity';
 import { Lesson } from './entities/lesson.entity';
 import { Payment } from './entities/payment.entity';
 import { Settings } from './entities/settings.entity';
+import { NotificationsModule } from './notifications/notifications.module';
+import { Notification } from './entities/notification.entity';
 
 @Module({
   imports: [
@@ -20,7 +22,7 @@ import { Settings } from './entities/settings.entity';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'fayrouz_driving.db',
-      entities: [Student, Lesson, Payment, Settings],
+      entities: [Student, Lesson, Payment, Settings, Notification],
       synchronize: true, // Only for development
       logging: false,
     }),
@@ -28,6 +30,7 @@ import { Settings } from './entities/settings.entity';
     LessonsModule,
     PaymentsModule,
     SettingsModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/database/database.module.ts
+++ b/backend/src/database/database.module.ts
@@ -4,13 +4,14 @@ import { Student } from '../entities/student.entity';
 import { Lesson } from '../entities/lesson.entity';
 import { Payment } from '../entities/payment.entity';
 import { Settings } from '../entities/settings.entity';
+import { Notification } from '../entities/notification.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'fayrouz_driving.db',
-      entities: [Student, Lesson, Payment, Settings],
+      entities: [Student, Lesson, Payment, Settings, Notification],
       synchronize: true,
     }),
   ],

--- a/backend/src/dto/notifications/create-notification.dto.ts
+++ b/backend/src/dto/notifications/create-notification.dto.ts
@@ -1,0 +1,23 @@
+import { IsNotEmpty, IsString, IsDateString, IsOptional, IsNumber, IsBoolean } from 'class-validator';
+
+export class CreateNotificationDto {
+  @IsNotEmpty({ message: 'عنوان الإشعار مطلوب' })
+  @IsString({ message: 'عنوان الإشعار يجب أن يكون نص' })
+  title: string;
+
+  @IsNotEmpty({ message: 'محتوى الإشعار مطلوب' })
+  @IsString({ message: 'محتوى الإشعار يجب أن يكون نص' })
+  message: string;
+
+  @IsNotEmpty({ message: 'تاريخ ووقت الإشعار مطلوب' })
+  @IsDateString({}, { message: 'تاريخ ووقت الإشعار غير صحيح' })
+  scheduledDateTime: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'معرف الدرس يجب أن يكون رقم' })
+  lessonId?: number;
+
+  @IsOptional()
+  @IsBoolean({ message: 'حالة الإرسال يجب أن تكون صحيح أو خطأ' })
+  isSent?: boolean;
+}

--- a/backend/src/dto/notifications/update-notification.dto.ts
+++ b/backend/src/dto/notifications/update-notification.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateNotificationDto } from './create-notification.dto';
+
+export class UpdateNotificationDto extends PartialType(CreateNotificationDto) {}

--- a/backend/src/entities/notification.entity.ts
+++ b/backend/src/entities/notification.entity.ts
@@ -1,0 +1,33 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Lesson } from './lesson.entity';
+
+@Entity('notifications')
+export class Notification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 100 })
+  title: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ type: 'datetime' })
+  scheduledDateTime: Date;
+
+  @Column({ type: 'boolean', default: false })
+  isSent: boolean;
+
+  @Column({ type: 'int', nullable: true })
+  lessonId?: number;
+
+  @ManyToOne(() => Lesson, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'lessonId' })
+  lesson?: Lesson;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notifications.controller.spec.ts
+++ b/backend/src/notifications/notifications.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [{ provide: NotificationsService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<NotificationsController>(NotificationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { CreateNotificationDto } from '../dto/notifications/create-notification.dto';
+import { UpdateNotificationDto } from '../dto/notifications/update-notification.dto';
+
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Post()
+  create(@Body() createNotificationDto: CreateNotificationDto) {
+    return this.notificationsService.create(createNotificationDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.notificationsService.findAll();
+  }
+
+  @Get('pending')
+  findPending() {
+    return this.notificationsService.findPending();
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateDto: UpdateNotificationDto) {
+    return this.notificationsService.update(+id, updateDto);
+  }
+
+  @Patch(':id/mark-sent')
+  markAsSent(@Param('id') id: string) {
+    return this.notificationsService.markAsSent(+id);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.notificationsService.remove(+id);
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+import { Notification } from '../entities/notification.entity';
+import { LessonsModule } from '../lessons/lessons.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification]), LessonsModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService]
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.spec.ts
+++ b/backend/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from './notifications.service';
+import { LessonsService } from '../lessons/lessons.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Notification } from '../entities/notification.entity';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsService,
+        { provide: LessonsService, useValue: { findTodayLessons: jest.fn() } },
+        { provide: getRepositoryToken(Notification), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import { Notification } from '../entities/notification.entity';
+import { CreateNotificationDto } from '../dto/notifications/create-notification.dto';
+import { UpdateNotificationDto } from '../dto/notifications/update-notification.dto';
+import { LessonsService } from '../lessons/lessons.service';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @InjectRepository(Notification)
+    private notificationsRepository: Repository<Notification>,
+    private lessonsService: LessonsService,
+  ) {}
+
+  async create(createNotificationDto: CreateNotificationDto): Promise<Notification> {
+    const notification = this.notificationsRepository.create({
+      ...createNotificationDto,
+      scheduledDateTime: new Date(createNotificationDto.scheduledDateTime)
+    });
+    return await this.notificationsRepository.save(notification);
+  }
+
+  async findAll(): Promise<Notification[]> {
+    return await this.notificationsRepository.find({
+      order: { scheduledDateTime: 'DESC' }
+    });
+  }
+
+  async findOne(id: number): Promise<Notification> {
+    const notification = await this.notificationsRepository.findOne({ where: { id } });
+    if (!notification) {
+      throw new NotFoundException('الإشعار غير موجود');
+    }
+    return notification;
+  }
+
+  async update(id: number, updateDto: UpdateNotificationDto): Promise<Notification> {
+    const notification = await this.findOne(id);
+    Object.assign(notification, {
+      ...updateDto,
+      scheduledDateTime: updateDto.scheduledDateTime
+        ? new Date(updateDto.scheduledDateTime)
+        : notification.scheduledDateTime
+    });
+    return await this.notificationsRepository.save(notification);
+  }
+
+  async remove(id: number): Promise<void> {
+    const notification = await this.findOne(id);
+    await this.notificationsRepository.remove(notification);
+  }
+
+  async generateTodayLessonNotifications(): Promise<void> {
+    const lessons = await this.lessonsService.findTodayLessons();
+    for (const lesson of lessons) {
+      const exists = await this.notificationsRepository.findOne({ where: { lessonId: lesson.id } });
+      if (!exists) {
+        const notification = this.notificationsRepository.create({
+          title: 'تذكير بالدرس',
+          message: `لديك درس مع ${lesson.student?.name || ''} في ${lesson.scheduledDateTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`,
+          scheduledDateTime: lesson.scheduledDateTime,
+          lessonId: lesson.id,
+        });
+        await this.notificationsRepository.save(notification);
+      }
+    }
+  }
+
+  async findPending(): Promise<Notification[]> {
+    await this.generateTodayLessonNotifications();
+    const now = new Date();
+    return await this.notificationsRepository.find({
+      where: { isSent: false, scheduledDateTime: LessThanOrEqual(now) },
+      order: { scheduledDateTime: 'ASC' }
+    });
+  }
+
+  async markAsSent(id: number): Promise<Notification> {
+    const notification = await this.findOne(id);
+    notification.isSent = true;
+    return await this.notificationsRepository.save(notification);
+  }
+}

--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -12,6 +12,7 @@ import {
   useMediaQuery,
   IconButton,
   Avatar,
+  Badge,
 } from '@mui/material';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import PeopleIcon from '@mui/icons-material/People';
@@ -19,6 +20,8 @@ import EventIcon from '@mui/icons-material/Event';
 import PaymentIcon from '@mui/icons-material/Payment';
 import DriveEtaIcon from '@mui/icons-material/DriveEta';
 import NotificationsIcon from '@mui/icons-material/Notifications';
+import { getPendingNotifications } from '../../services/notificationService';
+import { Notification } from '../../types';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -36,6 +39,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [currentTime, setCurrentTime] = useState(new Date());
+  const [pendingNotifications, setPendingNotifications] = useState<Notification[]>([]);
 
   // Update time every minute
   useEffect(() => {
@@ -43,6 +47,21 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       setCurrentTime(new Date());
     }, 60000);
     return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      try {
+        const data = await getPendingNotifications();
+        setPendingNotifications(data);
+      } catch (error) {
+        console.error('Failed to fetch notifications', error);
+      }
+    };
+
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, 60000);
+    return () => clearInterval(interval);
   }, []);
 
   const getCurrentNavIndex = () => {
@@ -136,17 +155,19 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             >
               {formatTime(currentTime)}
             </Typography>
-            <IconButton 
-              sx={{ 
+            <IconButton
+              sx={{
                 color: 'rgba(255, 255, 255, 0.8)',
-                '&:hover': { 
+                '&:hover': {
                   backgroundColor: 'rgba(255, 255, 255, 0.1)',
                   transform: 'scale(1.1)',
                 },
                 transition: 'all 0.3s ease',
               }}
             >
-              <NotificationsIcon />
+              <Badge badgeContent={pendingNotifications.length} color="error">
+                <NotificationsIcon />
+              </Badge>
             </IconButton>
           </Box>
         </Toolbar>

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { Notification } from '../types';
+
+const API_URL = '/notifications';
+
+export const getNotifications = async (): Promise<Notification[]> => {
+  const response = await axios.get(API_URL);
+  return response.data;
+};
+
+export const getPendingNotifications = async (): Promise<Notification[]> => {
+  const response = await axios.get(`${API_URL}/pending`);
+  return response.data;
+};
+
+export const createNotification = async (
+  notification: Omit<Notification, 'id' | 'isSent' | 'createdAt' | 'updatedAt'>
+): Promise<Notification> => {
+  const response = await axios.post(API_URL, notification);
+  return response.data;
+};
+
+export const updateNotification = async (
+  id: number,
+  notification: Partial<Notification>
+): Promise<Notification> => {
+  const response = await axios.patch(`${API_URL}/${id}`, notification);
+  return response.data;
+};
+
+export const deleteNotification = async (id: number): Promise<void> => {
+  await axios.delete(`${API_URL}/${id}`);
+};
+
+export const markNotificationAsSent = async (id: number): Promise<Notification> => {
+  const response = await axios.patch(`${API_URL}/${id}/mark-sent`, {});
+  return response.data;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,3 +50,14 @@ export interface Payment {
   updatedAt: Date;
   student?: Student;
 }
+
+export interface Notification {
+  id: number;
+  title: string;
+  message: string;
+  scheduledDateTime: Date;
+  isSent: boolean;
+  lessonId?: number;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- add Notification entity to store reminder info for lessons
- implement notifications service and controller with pending lookup and mark-as-sent endpoint
- wire notifications module into app and database
- expose notification service and badge in frontend

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: react-scripts not found; `npm install --legacy-peer-deps` raised ERESOLVE could not resolve dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689614b1472483289edbf845b5fb1ad2