### PR TITLE
feat: offline data support with production API URL

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [https://drivinginstructorapp-production.up.railway.app](https://drivinginstructorapp-production.up.railway.app) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:3001",
+  "proxy": "https://drivinginstructorapp-production.up.railway.app",
   "dependencies": {
     "@capacitor-community/sqlite": "^7.0.1",
     "@capacitor/android": "^7.4.2",

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -29,6 +29,7 @@ import { getPayments } from '../../services/paymentService';
 import { Student, Lesson, Payment } from '../../types';
 import { formatCurrency } from '../../utils/currency';
 import Loading from '../common/Loading';
+import useOfflineStorage from '../../hooks/useOfflineStorage';
 
 interface DashboardStats {
   totalStudents: number;
@@ -231,13 +232,29 @@ const Dashboard: React.FC = () => {
   const [upcomingLessons, setUpcomingLessons] = useState<Lesson[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const {
+    getData: getStudentsData,
+    isOnline: studentsOnline,
+    syncData: syncStudents,
+  } = useOfflineStorage<Student[]>('students', getStudents);
+  const {
+    getData: getLessonsData,
+    isOnline: lessonsOnline,
+    syncData: syncLessons,
+  } = useOfflineStorage<Lesson[]>('lessons', getLessons);
+  const {
+    getData: getPaymentsData,
+    isOnline: paymentsOnline,
+    syncData: syncPayments,
+  } = useOfflineStorage<Payment[]>('payments', getPayments);
+
   useEffect(() => {
     const fetchDashboardData = async () => {
       try {
         const [studentsData, lessonsData, paymentsData] = await Promise.all([
-          getStudents(),
-          getLessons(),
-          getPayments(),
+          getStudentsData(),
+          getLessonsData(),
+          getPaymentsData(),
         ]);
 
         // Calculate stats
@@ -289,6 +306,12 @@ const Dashboard: React.FC = () => {
 
     fetchDashboardData();
   }, []);
+
+  useEffect(() => {
+    syncStudents();
+    syncLessons();
+    syncPayments();
+  }, [studentsOnline, lessonsOnline, paymentsOnline, syncStudents, syncLessons, syncPayments]);
 
   if (loading) {
     return <Loading />;

--- a/frontend/src/components/lessons/LessonCalendar.tsx
+++ b/frontend/src/components/lessons/LessonCalendar.tsx
@@ -5,6 +5,7 @@ import { getStudents } from '../../services/studentService';
 import LessonForm from './LessonForm';
 import Loading from '../common/Loading';
 import LessonCard from './LessonCard';
+import useOfflineStorage from '../../hooks/useOfflineStorage';
 import {
   Box,
   Typography,
@@ -28,18 +29,36 @@ const LessonCalendar: React.FC = () => {
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
   const [dialogTitle, setDialogTitle] = useState('إضافة درس جديد');
   const [loading, setLoading] = useState(true);
+  const {
+    getData: getLessonsData,
+    isOnline: lessonsOnline,
+    syncData: syncLessons,
+  } = useOfflineStorage<Lesson[]>('lessons', getLessons);
+  const {
+    getData: getStudentsData,
+    isOnline: studentsOnline,
+    syncData: syncStudents,
+  } = useOfflineStorage<Student[]>('students', getStudents);
 
   useEffect(() => {
     (async () => {
       try {
-        const [lessonData, studentData] = await Promise.all([getLessons(), getStudents()]);
+        const [lessonData, studentData] = await Promise.all([
+          getLessonsData(),
+          getStudentsData(),
+        ]);
         setLessons(lessonData);
         setStudents(studentData);
       } finally {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [getLessonsData, getStudentsData]);
+
+  useEffect(() => {
+    syncLessons();
+    syncStudents();
+  }, [lessonsOnline, studentsOnline, syncLessons, syncStudents]);
 
   const handleOpen = (lesson?: Lesson) => {
     if (lesson) {

--- a/frontend/src/components/students/StudentList.tsx
+++ b/frontend/src/components/students/StudentList.tsx
@@ -38,6 +38,7 @@ import { getStudents, createStudent, deleteStudent, updateStudent } from '../../
 import { formatCurrency } from '../../utils/currency';
 import StudentCard from './StudentCard';
 import Loading from '../common/Loading';
+import useOfflineStorage from '../../hooks/useOfflineStorage';
 
 const StudentList: React.FC = () => {
   const theme = useTheme();
@@ -60,10 +61,15 @@ const StudentList: React.FC = () => {
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const { isOnline, getData, syncData } = useOfflineStorage<Student[]>(
+    'students',
+    getStudents
+  );
+
   useEffect(() => {
     (async () => {
       try {
-        const list = await getStudents();
+        const list = await getData();
         setStudents(list);
         setFiltered(list);
       } catch (err) {
@@ -72,7 +78,11 @@ const StudentList: React.FC = () => {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [getData]);
+
+  useEffect(() => {
+    syncData();
+  }, [isOnline, syncData]);
 
   // filter as user types
   useEffect(() => {

--- a/frontend/src/hooks/useOfflineStorage.ts
+++ b/frontend/src/hooks/useOfflineStorage.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Hybrid online/offline data handler.
+ * Stores API data in localStorage when online and
+ * retrieves cached data when offline.
+ */
+export const useOfflineStorage = <T>(
+  key: string,
+  fetcher: () => Promise<T>
+) => {
+  const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
+
+  useEffect(() => {
+    const updateStatus = () => setIsOnline(navigator.onLine);
+    window.addEventListener('online', updateStatus);
+    window.addEventListener('offline', updateStatus);
+    return () => {
+      window.removeEventListener('online', updateStatus);
+      window.removeEventListener('offline', updateStatus);
+    };
+  }, []);
+
+  const syncData = useCallback(async () => {
+    if (isOnline) {
+      const data = await fetcher();
+      localStorage.setItem(key, JSON.stringify(data));
+    }
+  }, [isOnline, fetcher, key]);
+
+  const getData = useCallback(async (): Promise<T> => {
+    if (isOnline) {
+      const data = await fetcher();
+      localStorage.setItem(key, JSON.stringify(data));
+      return data;
+    }
+    const cached = localStorage.getItem(key);
+    return cached ? (JSON.parse(cached) as T) : ([] as unknown as T);
+  }, [isOnline, fetcher, key]);
+
+  return { isOnline, syncData, getData };
+};
+
+export default useOfflineStorage;
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,9 +2,9 @@
 import axios from 'axios';
 
 const instance = axios.create({
-  baseURL: 'http://localhost:3001',
+  baseURL: 'https://drivinginstructorapp-production.up.railway.app',
   timeout: 1000,
-  headers: { 'X-Custom-Header': 'foobar' }
+  headers: { 'X-Custom-Header': 'foobar' },
 });
 
 export default instance;

--- a/frontend/src/services/lessonService.ts
+++ b/frontend/src/services/lessonService.ts
@@ -1,29 +1,29 @@
 
-import axios from 'axios';
+import api from './api';
 import { Lesson } from '../types';
 
 const API_URL = '/lessons';
 
 export const getLessons = async (): Promise<Lesson[]> => {
-  const response = await axios.get(API_URL);
+  const response = await api.get(API_URL);
   return response.data;
 };
 
 export const getLesson = async (id: number): Promise<Lesson> => {
-  const response = await axios.get(`${API_URL}/${id}`);
+  const response = await api.get(`${API_URL}/${id}`);
   return response.data;
 };
 
 export const createLesson = async (lesson: Omit<Lesson, 'id' | 'createdAt' | 'updatedAt'>): Promise<Lesson> => {
-  const response = await axios.post(API_URL, lesson);
+  const response = await api.post(API_URL, lesson);
   return response.data;
 };
 
 export const updateLesson = async (id: number, lesson: Partial<Lesson>): Promise<Lesson> => {
-  const response = await axios.patch(`${API_URL}/${id}`, lesson);
+  const response = await api.patch(`${API_URL}/${id}`, lesson);
   return response.data;
 };
 
 export const deleteLesson = async (id: number): Promise<void> => {
-  await axios.delete(`${API_URL}/${id}`);
+  await api.delete(`${API_URL}/${id}`);
 };

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,22 +1,22 @@
-import axios from 'axios';
+import api from './api';
 import { Notification } from '../types';
 
 const API_URL = '/notifications';
 
 export const getNotifications = async (): Promise<Notification[]> => {
-  const response = await axios.get(API_URL);
+  const response = await api.get(API_URL);
   return response.data;
 };
 
 export const getPendingNotifications = async (): Promise<Notification[]> => {
-  const response = await axios.get(`${API_URL}/pending`);
+  const response = await api.get(`${API_URL}/pending`);
   return response.data;
 };
 
 export const createNotification = async (
   notification: Omit<Notification, 'id' | 'isSent' | 'createdAt' | 'updatedAt'>
 ): Promise<Notification> => {
-  const response = await axios.post(API_URL, notification);
+  const response = await api.post(API_URL, notification);
   return response.data;
 };
 
@@ -24,15 +24,15 @@ export const updateNotification = async (
   id: number,
   notification: Partial<Notification>
 ): Promise<Notification> => {
-  const response = await axios.patch(`${API_URL}/${id}`, notification);
+  const response = await api.patch(`${API_URL}/${id}`, notification);
   return response.data;
 };
 
 export const deleteNotification = async (id: number): Promise<void> => {
-  await axios.delete(`${API_URL}/${id}`);
+  await api.delete(`${API_URL}/${id}`);
 };
 
 export const markNotificationAsSent = async (id: number): Promise<Notification> => {
-  const response = await axios.patch(`${API_URL}/${id}/mark-sent`, {});
+  const response = await api.patch(`${API_URL}/${id}/mark-sent`, {});
   return response.data;
 };

--- a/frontend/src/services/paymentService.ts
+++ b/frontend/src/services/paymentService.ts
@@ -1,29 +1,29 @@
 
-import axios from 'axios';
+import api from './api';
 import { Payment } from '../types';
 
 const API_URL = '/payments';
 
 export const getPayments = async (): Promise<Payment[]> => {
-  const response = await axios.get(API_URL);
+  const response = await api.get(API_URL);
   return response.data;
 };
 
 export const getPayment = async (id: number): Promise<Payment> => {
-  const response = await axios.get(`${API_URL}/${id}`);
+  const response = await api.get(`${API_URL}/${id}`);
   return response.data;
 };
 
 export const createPayment = async (payment: Omit<Payment, 'id' | 'createdAt' | 'updatedAt'>): Promise<Payment> => {
-  const response = await axios.post(API_URL, payment);
+  const response = await api.post(API_URL, payment);
   return response.data;
 };
 
 export const updatePayment = async (id: number, payment: Partial<Payment>): Promise<Payment> => {
-  const response = await axios.patch(`${API_URL}/${id}`, payment);
+  const response = await api.patch(`${API_URL}/${id}`, payment);
   return response.data;
 };
 
 export const deletePayment = async (id: number): Promise<void> => {
-  await axios.delete(`${API_URL}/${id}`);
+  await api.delete(`${API_URL}/${id}`);
 };

--- a/frontend/src/services/studentService.ts
+++ b/frontend/src/services/studentService.ts
@@ -1,29 +1,29 @@
 
-import axios from 'axios';
+import api from './api';
 import { Student } from '../types';
 
 const API_URL = '/students';
 
 export const getStudents = async (): Promise<Student[]> => {
-  const response = await axios.get(API_URL);
+  const response = await api.get(API_URL);
   return response.data;
 };
 
 export const getStudent = async (id: number): Promise<Student> => {
-  const response = await axios.get(`${API_URL}/${id}`);
+  const response = await api.get(`${API_URL}/${id}`);
   return response.data;
 };
 
 export const createStudent = async (student: Omit<Student, 'id' | 'createdAt' | 'updatedAt'>): Promise<Student> => {
-  const response = await axios.post(API_URL, student);
+  const response = await api.post(API_URL, student);
   return response.data;
 };
 
 export const updateStudent = async (id: number, student: Partial<Student>): Promise<Student> => {
-  const response = await axios.patch(`${API_URL}/${id}`, student);
+  const response = await api.patch(`${API_URL}/${id}`, student);
   return response.data;
 };
 
 export const deleteStudent = async (id: number): Promise<void> => {
-  await axios.delete(`${API_URL}/${id}`);
+  await api.delete(`${API_URL}/${id}`);
 };


### PR DESCRIPTION
## Summary
- add `useOfflineStorage` hook to cache API data and use it when offline
- switch frontend services to the Railway production API
- refresh students, lessons, payments, and dashboard pages to use offline cache

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689637f352a483289a6203577717639f