### PR TITLE
feat: add offline local storage api

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,6 @@
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "@types/react-router-dom": "^5.3.3",
-        "axios": "^1.11.0",
         "date-fns": "^4.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -5877,17 +5876,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -9635,22 +9623,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -15183,12 +15155,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,6 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy": "https://drivinginstructorapp-production.up.railway.app",
   "dependencies": {
     "@capacitor-community/sqlite": "^7.0.1",
     "@capacitor/android": "^7.4.2",
@@ -24,7 +23,6 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@types/react-router-dom": "^5.3.3",
-    "axios": "^1.11.0",
     "date-fns": "^4.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,78 @@
+// Local storage based mock API for offline usage
+// Provides a minimal axios-like interface with get/post/patch/delete methods
 
-import axios from 'axios';
+export type RecordData = {
+  id: number;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: any;
+};
 
-const instance = axios.create({
-  baseURL: 'https://drivinginstructorapp-production.up.railway.app',
-  timeout: 1000,
-  headers: { 'X-Custom-Header': 'foobar' },
-});
+const parseUrl = (url: string): { collection: string; id: number | null } => {
+  const parts = url.split('/').filter(Boolean);
+  const collection = parts[0];
+  const id = parts.length > 1 ? parseInt(parts[1], 10) : null;
+  return { collection, id };
+};
 
-export default instance;
+const load = (collection: string): RecordData[] => {
+  const raw = localStorage.getItem(collection);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as RecordData[];
+  } catch {
+    return [];
+  }
+};
+
+const save = (collection: string, data: RecordData[]): void => {
+  localStorage.setItem(collection, JSON.stringify(data));
+};
+
+const delay = (ms = 50) => new Promise((res) => setTimeout(res, ms));
+
+const api = {
+  get: async (url: string) => {
+    const { collection, id } = parseUrl(url);
+    const data = load(collection);
+    await delay();
+    if (id === null) {
+      return { data };
+    }
+    return { data: data.find((item) => item.id === id) };
+  },
+  post: async (url: string, payload: any) => {
+    const { collection } = parseUrl(url);
+    const data = load(collection);
+    const item: RecordData = {
+      id: Date.now(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...payload,
+    };
+    data.push(item);
+    save(collection, data);
+    await delay();
+    return { data: item };
+  },
+  patch: async (url: string, payload: any) => {
+    const { collection, id } = parseUrl(url);
+    const data = load(collection);
+    const idx = data.findIndex((item) => item.id === id);
+    if (idx === -1) throw new Error('Item not found');
+    data[idx] = { ...data[idx], ...payload, updatedAt: new Date().toISOString() };
+    save(collection, data);
+    await delay();
+    return { data: data[idx] };
+  },
+  delete: async (url: string) => {
+    const { collection, id } = parseUrl(url);
+    const data = load(collection);
+    const filtered = data.filter((item) => item.id !== id);
+    save(collection, filtered);
+    await delay();
+    return { data: null };
+  },
+};
+
+export default api;


### PR DESCRIPTION
## Summary
- replace axios-based API with localStorage-backed mock to allow offline use
- drop remote proxy and axios dependency from frontend package.json

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689b246ab1d0832888b17d65b737675e