### PR TITLE
Improve navbar placement and student cleanup

### DIFF
--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -245,7 +245,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             position: 'fixed',
             left: 0,
             right: 0,
-            bottom: 'max(env(safe-area-inset-bottom), 12px)',  // sit above the gesture area
+            bottom: 'calc(env(safe-area-inset-bottom) + 24px)',  // raise above system nav
             zIndex: theme.zIndex.drawer + 1,
             display: 'flex',
             justifyContent: 'center',

--- a/frontend/src/components/students/StudentCard.tsx
+++ b/frontend/src/components/students/StudentCard.tsx
@@ -63,10 +63,11 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onEdit, onDelete }) 
   return (
     <Card
       sx={{
-        background: 'rgba(0, 0, 0, 0.9)',
-        backdropFilter: 'blur(20px)',
+        background: 'rgba(255,255,255,0.9)',
+        backdropFilter: 'blur(10px)',
         borderRadius: 2,
-        border: '1px solid rgba(255,255,255,0.2)',
+        border: '1px solid rgba(0,0,0,0.1)',
+        boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
         overflow: 'hidden',
         position: 'relative',
         '&::before': {
@@ -95,7 +96,7 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onEdit, onDelete }) 
           <Box sx={{ ml: 2, flex: 1, minWidth: 0 }}>
             <Typography
               variant={isMobile ? 'h6' : 'h5'}
-              sx={{ fontWeight: 700, color: '#FFFFFF', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+              sx={{ fontWeight: 700, color: '#1F2937', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
             >
               {student.firstName} {student.lastName}
             </Typography>
@@ -130,14 +131,14 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, onEdit, onDelete }) 
               </Grid>
             ))}
           </Grid>
-          <Box sx={{ mt: 1, p: 2, background: 'rgba(248,250,252,0.6)', borderRadius: 1 }}>
-            <Typography variant="body2" sx={{ mb: 1 }}>
+          <Box sx={{ mt: 1, p: 2, background: 'rgba(241,245,249,0.8)', borderRadius: 1 }}>
+            <Typography variant="body2" sx={{ mb: 1, color: '#1F2937' }}>
               <Phone fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> {student.phoneNumber}
             </Typography>
-            <Typography variant="body2" sx={{ mb: 1 }}>
+            <Typography variant="body2" sx={{ mb: 1, color: '#1F2937' }}>
               <Person fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> {student.cin}
             </Typography>
-            <Typography variant="body2">
+            <Typography variant="body2" sx={{ color: '#1F2937' }}>
               <Schedule fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> {new Date(student.dateOfBirth).toLocaleDateString('ar-TN')}
             </Typography>
           </Box>

--- a/frontend/src/services/studentService.ts
+++ b/frontend/src/services/studentService.ts
@@ -1,6 +1,8 @@
 
 import api from './api';
 import { Student } from '../types';
+import { getLessons, deleteLesson } from './lessonService';
+import { getPayments, deletePayment } from './paymentService';
 
 const API_URL = '/students';
 
@@ -26,4 +28,15 @@ export const updateStudent = async (id: number, student: Partial<Student>): Prom
 
 export const deleteStudent = async (id: number): Promise<void> => {
   await api.delete(`${API_URL}/${id}`);
+
+  const [lessons, payments] = await Promise.all([getLessons(), getPayments()]);
+
+  const lessonDeletes = lessons
+    .filter(l => l.studentId === id)
+    .map(l => deleteLesson(l.id));
+  const paymentDeletes = payments
+    .filter(p => p.studentId === id)
+    .map(p => deletePayment(p.id));
+
+  await Promise.all([...lessonDeletes, ...paymentDeletes]);
 };


### PR DESCRIPTION
## Summary
- Raise mobile bottom navigation to avoid system button overlap
- Remove orphaned lessons and payments when deleting a student
- Refresh student card with a lighter background and readable text

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689bcaf154fc83288ca76420d1d2483d