### PR TITLE
Add splash screen and refine dark theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Layout from './components/common/Layout';
+import SplashScreen from './components/common/SplashScreen';
 import DashboardPage from './pages/DashboardPage';
 import StudentsPage from './pages/StudentsPage';
 import LessonsPage from './pages/LessonsPage';
 import PaymentsPage from './pages/PaymentsPage';
 
 function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (showSplash) {
+    return <SplashScreen />;
+  }
+
   return (
     <Router>
       <Layout>

--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -113,8 +113,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         minHeight: '100vh',
         direction: 'rtl',
         background: `linear-gradient(135deg,
-            rgba(30, 58, 138, 0.6) 0%,
-            rgba(17, 24, 39, 0.95) 100%)`,
+            rgba(30, 41, 59, 0.6) 0%,
+            rgba(15, 23, 42, 0.95) 100%)`,
         backgroundAttachment: 'fixed',
       }}
     >
@@ -122,9 +122,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       <AppBar
         position="fixed"
         sx={{
-          background: 'linear-gradient(135deg, #7C3AED 0%, #0D9488 100%)',
+          background: 'linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%)',
           backdropFilter: 'blur(20px)',
-          boxShadow: '0 8px 32px rgba(30, 58, 138, 0.3)',
+          boxShadow: '0 8px 32px rgba(30, 41, 59, 0.3)',
           zIndex: theme.zIndex.drawer + 1,
           paddingTop: 'env(safe-area-inset-top)',
         }}
@@ -233,7 +233,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               left: 0,
               right: 0,
               height: '2px',
-              background: 'linear-gradient(90deg, #2563EB, #16A34A, #F59E0B)',
+              background: 'linear-gradient(90deg, var(--primary-color), var(--secondary-color))',
             }
           }}
         >
@@ -278,7 +278,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   px: 1.5,
                   py: 0.75,
                   '&.Mui-selected': {
-                    color: '#1E40AF',
+                    color: 'var(--primary-color)',
                     '& .MuiBottomNavigationAction-label': { fontSize: '0.75rem', fontWeight: 600 },
                     '& .MuiSvgIcon-root': { transform: 'scale(1.15)' }
                   },
@@ -286,7 +286,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   '& .MuiBottomNavigationAction-label': { fontFamily: '"Cairo", sans-serif', fontSize: '0.7rem', mt: '4px' },
                   borderRadius: '12px',
                   transition: 'all 0.25s ease',
-                  '&:hover': { backgroundColor: 'rgba(30,58,138,0.18)' },
+                  '&:hover': { backgroundColor: 'rgba(30,41,59,0.18)' },
                 }
               }}
             >
@@ -337,16 +337,16 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   height: '56px',
                   borderRadius: '16px',
                   backgroundColor: isActive
-                    ? 'rgba(30, 58, 138, 0.2)'
+                    ? 'rgba(30, 41, 59, 0.2)'
                     : 'transparent',
-                  color: isActive ? '#1E40AF' : '#D1D5DB',
+                  color: isActive ? 'var(--primary-color)' : '#D1D5DB',
                   border: isActive
-                    ? '2px solid rgba(30, 58, 138, 0.3)'
+                    ? '2px solid rgba(30, 41, 59, 0.3)'
                     : '2px solid transparent',
                   '&:hover': {
-                    backgroundColor: 'rgba(30, 58, 138, 0.2)',
+                    backgroundColor: 'rgba(30, 41, 59, 0.2)',
                     transform: 'translateY(-2px)',
-                    boxShadow: '0 4px 16px rgba(30, 58, 138, 0.4)',
+                    boxShadow: '0 4px 16px rgba(30, 41, 59, 0.4)',
                   },
                   transition: 'all 0.3s ease',
                   '& .MuiSvgIcon-root': {

--- a/frontend/src/components/common/SplashScreen.tsx
+++ b/frontend/src/components/common/SplashScreen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+const SplashScreen: React.FC = () => (
+  <Box
+    sx={{
+      height: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'var(--background-primary)',
+    }}
+  >
+    <img src="/splash.png" alt="App Splash" style={{ maxWidth: '60%' }} />
+  </Box>
+);
+
+export default SplashScreen;

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -357,7 +357,7 @@ const Dashboard: React.FC = () => {
             value={stats.totalStudents}
             subtitle={`${stats.activeStudents} نشط`}
             icon={<People />}
-            color="#1E40AF"
+            color="#1E293B"
             progress={activeRate}
             onClick={() => navigate('/students')}
           />
@@ -368,7 +368,7 @@ const Dashboard: React.FC = () => {
             value={stats.todayLessons}
             subtitle={`من ${stats.totalLessons} إجمالي`}
             icon={<Event />}
-            color="#0D9488"
+            color="#334155"
             trend={15} // Placeholder trend value
             onClick={() => navigate('/lessons')}
           />
@@ -452,7 +452,7 @@ const Dashboard: React.FC = () => {
                     >
                       <Avatar
                         sx={{
-                          background: `linear-gradient(135deg, #2563EB${index * 20 + 20}, #16A34A${index * 15 + 15})`,
+                          background: `linear-gradient(135deg, #1E293B${index * 20 + 20}, #334155${index * 15 + 15})`,
                           width: 40,
                           height: 40,
                           fontSize: '1rem',

--- a/frontend/src/components/lessons/LessonCard.tsx
+++ b/frontend/src/components/lessons/LessonCard.tsx
@@ -40,7 +40,7 @@ const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDele
       case 'completed':
         return '#16A34A';
       case 'scheduled':
-        return '#2563EB';
+        return '#1E293B';
       case 'cancelled':
         return '#DC2626';
       default:
@@ -87,7 +87,7 @@ const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDele
           {isToday && (
             <Chip label="درس اليوم" color="warning" size="small" sx={{ fontWeight: 600, mr: 1 }} />
           )}
-          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#2563EB' }}>
+          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#1E293B' }}>
             {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
           </IconButton>
         </Box>

--- a/frontend/src/components/payements/PaymentTracker.tsx
+++ b/frontend/src/components/payements/PaymentTracker.tsx
@@ -70,7 +70,7 @@ const PaymentCard: React.FC<{ payment: Payment; student?: Student; onEdit: () =>
     >
       <CardContent sx={{ p: isMobile ? 2 : 3 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-          <Avatar sx={{ background: `linear-gradient(135deg, #2563EB, #16A34A)`, color: 'white' }}>
+          <Avatar sx={{ background: `linear-gradient(135deg, #1E293B, #334155)`, color: 'white' }}>
             <Receipt />
           </Avatar>
           <Box sx={{ flex: 1, ml: 2 }}>
@@ -81,7 +81,7 @@ const PaymentCard: React.FC<{ payment: Payment; student?: Student; onEdit: () =>
               {student ? `${student.firstName} ${student.lastName}` : 'طالب غير معروف'}
             </Typography>
           </Box>
-          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#2563EB' }}>
+          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#1E293B' }}>
             {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
           </IconButton>
         </Box>

--- a/frontend/src/components/students/StudentCard.tsx
+++ b/frontend/src/components/students/StudentCard.tsx
@@ -40,7 +40,7 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return '#2563EB'; // Blue-600
+      case 'active': return '#1E293B'; // Slate-800
       case 'completed': return '#16A34A'; // Green-600
       case 'suspended': return '#DC2626'; // Red-600
       default: return '#6B7280'; // Gray-500
@@ -113,7 +113,7 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
               sx={{ mt: 1, background: `${getStatusColor(student.status)}15`, color: getStatusColor(student.status), fontWeight: 600 }}
             />
           </Box>
-          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#2563EB' }}>
+          <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#1E293B' }}>
             {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
           </IconButton>
         </Box>
@@ -121,9 +121,9 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
         <Collapse in={expanded} timeout="auto" unmountOnExit>
           <Grid container spacing={1} sx={{ mb: 1 }}>
             {[
-              { label: 'دروس مكتملة', value: completedLessonsCount, color: '#2563EB' },
+              { label: 'دروس مكتملة', value: completedLessonsCount, color: '#1E293B' },
               { label: 'دروس مدفوعة', value: paidLessonsCount, color: '#16A34A' },
-              { label: 'المدفوعات', value: formatCurrency(totalPayments), color: '#0D9488' },
+              { label: 'المدفوعات', value: formatCurrency(totalPayments), color: '#334155' },
               { label: 'المتبقي', value: formatCurrency(balanceAmount), color: balanceAmount > 0 ? '#F59E0B' : '#6B7280' },
             ].map((stat, idx) => (
               <Grid size={{ xs: 6, sm: 3 }} key={idx}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,9 +4,9 @@
 
 /* Root Variables */
 :root {
-  --primary-color: #1E40AF;
-  --secondary-color: #0D9488;
-  --accent-color: #F97316;
+  --primary-color: #1E293B;
+  --secondary-color: #334155;
+  --accent-color: #64748B;
   --success-color: #059669;
   --warning-color: #D97706;
   --error-color: #EF4444;

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -3,8 +3,8 @@ import { createTheme } from '@mui/material/styles';
 const theme = createTheme({
   palette: {
     mode: 'dark',
-    primary: { main: '#7C3AED' },
-    secondary: { main: '#0D9488' },
+    primary: { main: '#1E293B' },
+    secondary: { main: '#334155' },
     background: {
       default: '#0F172A',
       paper: '#1E293B',


### PR DESCRIPTION
## Summary
- Add simple splash screen that delays for 2 seconds before showing the dashboard
- Replace bright blue palette with a muted dark scheme and update layout gradients
- Align dashboard and card components with the new theme colors

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689c8b394ff483289b94f92084699558