### PR TITLE
Add exam scheduling and offline reminders

### DIFF
--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -21,6 +21,7 @@ import PaymentIcon from '@mui/icons-material/Payment';
 import DriveEtaIcon from '@mui/icons-material/DriveEta';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { getPendingNotifications, markNotificationAsSent } from '../../services/notificationService';
+import generateReminders from '../../services/reminderService';
 import { Notification } from '../../types';
 import NotificationMenu from './NotificationMenu';
 
@@ -71,6 +72,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   useEffect(() => {
     const fetchNotifications = async () => {
       try {
+        await generateReminders();
         const data = await getPendingNotifications();
         setPendingNotifications(data);
       } catch (error) {

--- a/frontend/src/components/lessons/LessonCalendar.tsx
+++ b/frontend/src/components/lessons/LessonCalendar.tsx
@@ -100,6 +100,11 @@ const LessonCalendar: React.FC = () => {
     setLessons(prev => prev.filter(l => l.id !== id));
   };
 
+  const handleMarkDone = async (id: number) => {
+    const updatedLesson = await updateLesson(id, { status: 'completed' });
+    setLessons(prev => prev.map(l => (l.id === id ? updatedLesson : l)));
+  };
+
   if (loading) {
     return <Loading />;
   }
@@ -136,6 +141,7 @@ const LessonCalendar: React.FC = () => {
               student={students.find(s => s.id === lesson.studentId)}
               onEdit={() => handleOpen(lesson)}
               onDelete={handleDeleteLesson}
+              onMarkDone={handleMarkDone}
             />
           </Grid>
         ))}

--- a/frontend/src/components/lessons/LessonCard.tsx
+++ b/frontend/src/components/lessons/LessonCard.tsx
@@ -17,6 +17,7 @@ import {
   ExpandLess,
   Edit,
   Delete as DeleteIcon,
+  Check,
 } from '@mui/icons-material';
 
 interface LessonCardProps {
@@ -24,9 +25,10 @@ interface LessonCardProps {
   student?: Student;
   onEdit: (lesson: Lesson) => void;
   onDelete: (id: number) => void;
+  onMarkDone: (id: number) => void;
 }
 
-const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDelete }) => {
+const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDelete, onMarkDone }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [expanded, setExpanded] = useState(false);
@@ -105,7 +107,12 @@ const LessonCard: React.FC<LessonCardProps> = ({ lesson, student, onEdit, onDele
             </Typography>
           )}
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-            <Button size="small" onClick={() => onEdit(lesson)} startIcon={<Edit fontSize="small" />}>
+            {lesson.status !== 'completed' && (
+              <Button size="small" color="success" onClick={() => onMarkDone(lesson.id)} startIcon={<Check fontSize="small" />}>
+                تم
+              </Button>
+            )}
+            <Button size="small" onClick={() => onEdit(lesson)} startIcon={<Edit fontSize="small" />}> 
               تعديل
             </Button>
             <Button

--- a/frontend/src/components/lessons/LessonForm.tsx
+++ b/frontend/src/components/lessons/LessonForm.tsx
@@ -133,7 +133,7 @@ const LessonForm: React.FC<Props> = ({ students, onSubmit, initialData }) => {
           onChange={e => setLessonType(e.target.value)}
         >
           <MenuItem value="practical">عملي</MenuItem>
-          <MenuItem value="theoretical">نظري</MenuItem>
+          <MenuItem value="park">بارك</MenuItem>
           <MenuItem value="exam_prep">تحضير للاختبار</MenuItem>
         </Select>
       </FormControl>

--- a/frontend/src/components/students/StudentCard.tsx
+++ b/frontend/src/components/students/StudentCard.tsx
@@ -24,6 +24,7 @@ import {
 } from '@mui/icons-material';
 import { Student, Lesson, Payment } from '../../types';
 import { formatCurrency } from '../../utils/currency';
+import EventIcon from '@mui/icons-material/Event';
 
 interface StudentCardProps {
   student: Student;
@@ -37,6 +38,14 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [expanded, setExpanded] = useState(false);
+
+  const isConduiteExamToday =
+    student.conduiteExamDate &&
+    new Date(student.conduiteExamDate).toDateString() === new Date().toDateString();
+
+  const isParkExamToday =
+    student.parkExamDate &&
+    new Date(student.parkExamDate).toDateString() === new Date().toDateString();
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -73,7 +82,9 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
         background: 'rgba(255,255,255,0.9)',
         backdropFilter: 'blur(10px)',
         borderRadius: 2,
-        border: '1px solid rgba(0,0,0,0.1)',
+        border: (isConduiteExamToday || isParkExamToday)
+          ? '2px solid #F59E0B'
+          : '1px solid rgba(0,0,0,0.1)',
         boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
         overflow: 'hidden',
         position: 'relative',
@@ -112,6 +123,12 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
               size="small"
               sx={{ mt: 1, background: `${getStatusColor(student.status)}15`, color: getStatusColor(student.status), fontWeight: 600 }}
             />
+            {isConduiteExamToday && (
+              <Chip label="امتحان سياقة اليوم" color="warning" size="small" sx={{ mt: 1, fontWeight: 600 }} />
+            )}
+            {isParkExamToday && (
+              <Chip label="امتحان بارك اليوم" color="warning" size="small" sx={{ mt: 1, fontWeight: 600 }} />
+            )}
           </Box>
           <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ color: '#1E293B' }}>
             {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
@@ -148,6 +165,16 @@ const StudentCard: React.FC<StudentCardProps> = ({ student, lessons, payments, o
             <Typography variant="body2" sx={{ color: '#1F2937' }}>
               <Schedule fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> {new Date(student.dateOfBirth).toLocaleDateString('ar-TN')}
             </Typography>
+            {student.conduiteExamDate && (
+              <Typography variant="body2" sx={{ color: isConduiteExamToday ? 'warning.main' : '#1F2937', mt: 1 }}>
+                <EventIcon fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> امتحان سياقة: {new Date(student.conduiteExamDate).toLocaleDateString('ar-TN')}
+              </Typography>
+            )}
+            {student.parkExamDate && (
+              <Typography variant="body2" sx={{ color: isParkExamToday ? 'warning.main' : '#1F2937', mt: 0.5 }}>
+                <EventIcon fontSize="small" sx={{ verticalAlign: 'middle', mr: 0.5 }} /> امتحان بارك: {new Date(student.parkExamDate).toLocaleDateString('ar-TN')}
+              </Typography>
+            )}
           </Box>
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
             <Button size="small" onClick={() => onEdit(student)} startIcon={<Edit fontSize="small" />}>

--- a/frontend/src/components/students/StudentForm.tsx
+++ b/frontend/src/components/students/StudentForm.tsx
@@ -33,6 +33,8 @@ const StudentForm: React.FC<Props> = ({ student, onSubmit }) => {
   const [dateOfBirth, setDateOfBirth] = useState(student?.dateOfBirth || '');
   const [address, setAddress] = useState(student?.address || '');
   const [pricePerHour, setPricePerHour] = useState(student?.pricePerHour || 25);
+  const [conduiteExamDate, setConduiteExamDate] = useState(student?.conduiteExamDate || '');
+  const [parkExamDate, setParkExamDate] = useState(student?.parkExamDate || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,6 +53,8 @@ const StudentForm: React.FC<Props> = ({ student, onSubmit }) => {
       status: student?.status || 'active',
       notes: student?.notes || '',
       pricePerHour: pricePerHour,
+      conduiteExamDate,
+      parkExamDate,
     });
   };
 
@@ -178,6 +182,40 @@ const StudentForm: React.FC<Props> = ({ student, onSubmit }) => {
             value={pricePerHour}
             onChange={e => setPricePerHour(Number(e.target.value))}
             required
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <TextField
+            label="تاريخ امتحان السياقة"
+            type="date"
+            fullWidth
+            value={conduiteExamDate}
+            onChange={e => setConduiteExamDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <CalendarIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <TextField
+            label="تاريخ امتحان البارك"
+            type="date"
+            fullWidth
+            value={parkExamDate}
+            onChange={e => setParkExamDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <CalendarIcon />
+                </InputAdornment>
+              ),
+            }}
           />
         </Grid>
       </Grid>

--- a/frontend/src/components/students/StudentList.tsx
+++ b/frontend/src/components/students/StudentList.tsx
@@ -50,6 +50,8 @@ const StudentList: React.FC = () => {
     cin: '',
     dateOfBirth: '',
     licenseType: '',
+    conduiteExamDate: '',
+    parkExamDate: '',
   });
 
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
@@ -115,14 +117,14 @@ const StudentList: React.FC = () => {
       setForm(student);
       setDialogTitle('تعديل بيانات الطالب');
     } else {
-      setForm({ firstName: '', lastName: '', phoneNumber: '', cin: '', dateOfBirth: '', licenseType: '' });
+      setForm({ firstName: '', lastName: '', phoneNumber: '', cin: '', dateOfBirth: '', licenseType: '', conduiteExamDate: '', parkExamDate: '' });
       setDialogTitle('إضافة طالب جديد');
     }
     setOpenDialog(true);
   };
   const handleClose = () => {
     setOpenDialog(false);
-    setForm({ firstName: '', lastName: '', phoneNumber: '', cin: '', dateOfBirth: '', licenseType: '' });
+    setForm({ firstName: '', lastName: '', phoneNumber: '', cin: '', dateOfBirth: '', licenseType: '', conduiteExamDate: '', parkExamDate: '' });
     setAlert(null);
   };
 
@@ -315,6 +317,40 @@ const StudentList: React.FC = () => {
                 fullWidth
                 value={form.licenseType}
                 onChange={handleChange('licenseType')}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                label="تاريخ امتحان السياقة"
+                type="date"
+                fullWidth
+                value={form.conduiteExamDate}
+                onChange={handleChange('conduiteExamDate')}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Schedule />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                label="تاريخ امتحان البارك"
+                type="date"
+                fullWidth
+                value={form.parkExamDate}
+                onChange={handleChange('parkExamDate')}
+                InputLabelProps={{ shrink: true }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Schedule />
+                    </InputAdornment>
+                  ),
+                }}
               />
             </Grid>
           </Grid>

--- a/frontend/src/services/reminderService.ts
+++ b/frontend/src/services/reminderService.ts
@@ -1,0 +1,96 @@
+import { getStudents } from './studentService';
+import { getLessons } from './lessonService';
+import { getPayments } from './paymentService';
+import { getNotifications, createNotification } from './notificationService';
+import { Student, Lesson, Notification } from '../types';
+
+const showBrowserNotification = (title: string, message: string) => {
+  if ('Notification' in window) {
+    if (Notification.permission === 'granted') {
+      new Notification(title, { body: message });
+    } else if (Notification.permission !== 'denied') {
+      Notification.requestPermission();
+    }
+  }
+};
+
+export const generateReminders = async (): Promise<void> => {
+  const [students, lessons, payments, existing] = await Promise.all([
+    getStudents(),
+    getLessons(),
+    getPayments(),
+    getNotifications(),
+  ]);
+
+  const notifications = [...existing];
+  const exists = (title: string, message: string) =>
+    notifications.some(n => n.title === title && n.message === message);
+
+  const now = new Date();
+
+  // Payment reminders
+  students.forEach((student: Student) => {
+    const studentLessons = lessons.filter(
+      (l: Lesson) => l.studentId === student.id && new Date(l.scheduledDateTime) <= now
+    );
+    const totalPayments = payments
+      .filter(p => p.studentId === student.id)
+      .reduce((sum, p) => sum + p.amount, 0);
+    const balance = studentLessons.length * student.pricePerHour - totalPayments;
+    if (balance > 0) {
+      const title = 'تنبيه دفع';
+      const message = `الطالب ${student.firstName} ${student.lastName} لديه دروس غير مدفوعة`;
+      if (!exists(title, message)) {
+        createNotification({ title, message, scheduledDateTime: now.toISOString(), isSent: false });
+        showBrowserNotification(title, message);
+        notifications.push({ id: 0, title, message, scheduledDateTime: now.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+      }
+    }
+  });
+
+  // Lesson reminders for today
+  lessons.forEach((lesson: Lesson) => {
+    const lessonDate = new Date(lesson.scheduledDateTime);
+    if (lesson.status !== 'completed' && lessonDate.toDateString() === now.toDateString()) {
+      const student = students.find(s => s.id === lesson.studentId);
+      const title = 'تذكير درس';
+      const time = lessonDate.toLocaleTimeString('ar-TN', { hour: '2-digit', minute: '2-digit' });
+      const message = `درس مع ${student?.firstName} ${student?.lastName} اليوم في ${time}`;
+      if (!exists(title, message)) {
+        createNotification({ title, message, scheduledDateTime: lesson.scheduledDateTime, isSent: false, lessonId: lesson.id });
+        showBrowserNotification(title, message);
+        notifications.push({ id: 0, title, message, scheduledDateTime: lesson.scheduledDateTime, isSent: false, createdAt: '', updatedAt: '' } as Notification);
+      }
+    }
+  });
+
+  // Exam reminders
+  students.forEach((student: Student) => {
+    if (student.conduiteExamDate) {
+      const examDate = new Date(student.conduiteExamDate);
+      if (examDate.toDateString() === now.toDateString()) {
+        const title = 'تذكير امتحان';
+        const message = `امتحان السياقة لـ ${student.firstName} ${student.lastName} اليوم`;
+        if (!exists(title, message)) {
+          createNotification({ title, message, scheduledDateTime: examDate.toISOString(), isSent: false });
+          showBrowserNotification(title, message);
+          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+        }
+      }
+    }
+    if (student.parkExamDate) {
+      const examDate = new Date(student.parkExamDate);
+      if (examDate.toDateString() === now.toDateString()) {
+        const title = 'تذكير امتحان';
+        const message = `امتحان البارك لـ ${student.firstName} ${student.lastName} اليوم`;
+        if (!exists(title, message)) {
+          createNotification({ title, message, scheduledDateTime: examDate.toISOString(), isSent: false });
+          showBrowserNotification(title, message);
+          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+        }
+      }
+    }
+  });
+};
+
+export default generateReminders;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,8 @@ export interface Student {
   status: string;
   notes: string;
   pricePerHour: number;
+  conduiteExamDate?: string;
+  parkExamDate?: string;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- track conduite and park exam dates for students and show upcoming exams
- replace theoretical lesson type with park and allow marking lessons as done
- generate offline notifications for unpaid lessons, daily lessons and exams

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689cc22eeb7c83289f3f09031a1fd10e