### PR TITLE
refactor: use type-only Notification imports

### DIFF
--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -22,7 +22,7 @@ import DriveEtaIcon from '@mui/icons-material/DriveEta';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { getPendingNotifications, markNotificationAsSent } from '../../services/notificationService';
 import generateReminders from '../../services/reminderService';
-import { Notification } from '../../types';
+import type { Notification } from '../../types';
 import NotificationMenu from './NotificationMenu';
 
 interface LayoutProps {

--- a/frontend/src/components/common/NotificationMenu.tsx
+++ b/frontend/src/components/common/NotificationMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Menu, MenuItem, Typography, Box, IconButton } from '@mui/material';
-import { Notification } from '../../types';
+import type { Notification } from '../../types';
 import { Close } from '@mui/icons-material';
 
 interface NotificationMenuProps {

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { Notification } from '../types';
+import type { Notification } from '../types';
 
 const API_URL = '/notifications';
 

--- a/frontend/src/services/reminderService.ts
+++ b/frontend/src/services/reminderService.ts
@@ -2,7 +2,7 @@ import { getStudents } from './studentService';
 import { getLessons } from './lessonService';
 import { getPayments } from './paymentService';
 import { getNotifications, createNotification } from './notificationService';
-import { Student, Lesson, Notification } from '../types';
+import type { Student, Lesson, Notification as AppNotification } from '../types';
 
 const showBrowserNotification = (title: string, message: string) => {
   if ('Notification' in window) {
@@ -22,7 +22,7 @@ export const generateReminders = async (): Promise<void> => {
     getNotifications(),
   ]);
 
-  const notifications = [...existing];
+  const notifications: AppNotification[] = [...existing];
   const exists = (title: string, message: string) =>
     notifications.some(n => n.title === title && n.message === message);
 
@@ -43,7 +43,7 @@ export const generateReminders = async (): Promise<void> => {
       if (!exists(title, message)) {
         createNotification({ title, message, scheduledDateTime: now.toISOString(), isSent: false });
         showBrowserNotification(title, message);
-        notifications.push({ id: 0, title, message, scheduledDateTime: now.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+        notifications.push({ id: 0, title, message, scheduledDateTime: now.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as AppNotification);
       }
     }
   });
@@ -59,7 +59,7 @@ export const generateReminders = async (): Promise<void> => {
       if (!exists(title, message)) {
         createNotification({ title, message, scheduledDateTime: lesson.scheduledDateTime, isSent: false, lessonId: lesson.id });
         showBrowserNotification(title, message);
-        notifications.push({ id: 0, title, message, scheduledDateTime: lesson.scheduledDateTime, isSent: false, createdAt: '', updatedAt: '' } as Notification);
+        notifications.push({ id: 0, title, message, scheduledDateTime: lesson.scheduledDateTime, isSent: false, createdAt: '', updatedAt: '' } as AppNotification);
       }
     }
   });
@@ -74,7 +74,7 @@ export const generateReminders = async (): Promise<void> => {
         if (!exists(title, message)) {
           createNotification({ title, message, scheduledDateTime: examDate.toISOString(), isSent: false });
           showBrowserNotification(title, message);
-          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as AppNotification);
         }
       }
     }
@@ -86,7 +86,7 @@ export const generateReminders = async (): Promise<void> => {
         if (!exists(title, message)) {
           createNotification({ title, message, scheduledDateTime: examDate.toISOString(), isSent: false });
           showBrowserNotification(title, message);
-          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as Notification);
+          notifications.push({ id: 0, title, message, scheduledDateTime: examDate.toISOString(), isSent: false, createdAt: '', updatedAt: '' } as AppNotification);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Alias `Notification` to `AppNotification` in reminder service to avoid clash with browser API
- Treat `Notification` imports as type-only across services and components

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689cc67e69bc8328b4caad4aaa339326